### PR TITLE
Fix undefined default_position in Store.__init__

### DIFF
--- a/tock/machines.py
+++ b/tock/machines.py
@@ -25,9 +25,10 @@ class Store(syntax.String):
     position: int #: The head position
 
     def __init__(self, *args):
+        default_position = 0
         if len(args) == 0:
             values = []
-            position = 0
+            position = default_position
         elif len(args) == 1:
             if isinstance(args[0], Store):
                 values = args[0].values
@@ -38,13 +39,13 @@ class Store(syntax.String):
                 position = other.position
             else:
                 values = tuple(args[0])
-                position = 0
+                position = default_position
         elif len(args) == 2:
             values = args[0]
             position = args[1]
         else:
             raise TypeError("invalid arguments to Store")
-            
+
         syntax.String.__init__(self, values)
         object.__setattr__(self, 'position',
                            position if position is not None else default_position)


### PR DESCRIPTION
## Summary
- `Store.__init__` references `default_position` as a fallback but never defines it, causing a `NameError` when `position` is `None`
- Adds `default_position = 0` at the top of `__init__` and uses it consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)